### PR TITLE
Reduce ghc warnings

### DIFF
--- a/Data/RTree/Base.hs
+++ b/Data/RTree/Base.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoMonomorphismRestriction, DeriveFunctor, OverlappingInstances, DeriveDataTypeable, BangPatterns #-}
+{-# LANGUAGE NoMonomorphismRestriction, DeriveFunctor, DeriveDataTypeable, BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 {- |

--- a/Data/RTree/Strict.hs
+++ b/Data/RTree/Strict.hs
@@ -68,7 +68,6 @@ import           Data.Semigroup
 import           Data.Typeable (Typeable)
 
 import           Control.DeepSeq (NFData)
-import           Data.Functor
 import           GHC.Generics (Generic)
 --import           Data.RTree.Base hiding (RTree, singleton, fromList, insertWith, unionDistinctWith, unionWith, insert, mapMaybe, union, fromList', unionDistinct, unionDistinctSplit)
 import qualified Data.RTree.Base as Lazy
@@ -282,7 +281,7 @@ length :: RTree a -> Int
 length = Lazy.length . toLazy
 
 -- | 'RTree' is not really a Functor.
--- Because thsi law dowsn't hold:
+-- Because this law doesn't hold:
 --
 -- prop> fmap id = id
 instance Functor RTree where

--- a/data-r-tree.cabal
+++ b/data-r-tree.cabal
@@ -68,6 +68,7 @@ test-suite properties
   type:                 exitcode-stdio-1.0
   main-is:              RTreeProperties.hs
   other-extensions:     NoMonomorphismRestriction
+  ghc-options:  -Wall -fwarn-tabs -Wno-orphans
   hs-source-dirs:       test
 
 test-suite strict
@@ -82,4 +83,5 @@ test-suite strict
                       , test-framework-quickcheck2
   type:                 exitcode-stdio-1.0
   main-is:              RTreeStrict.hs
+  ghc-options:  -Wall -fwarn-tabs -Wno-orphans
   hs-source-dirs:       test

--- a/test/RTreeProperties.hs
+++ b/test/RTreeProperties.hs
@@ -15,8 +15,7 @@ import           Prelude                              hiding (lookup, map, null,
 import           Data.Binary (encode, decode)
 import           Data.Function (on)
 import           Data.List ((\\))
-import qualified Data.List as L (map, length)
-import           Debug.Trace                          (trace)
+import qualified Data.List as L (length)
 import           Control.Applicative ((<$>))
 
 import           Test.Framework
@@ -69,15 +68,10 @@ t_mbb6 = (MBB 0.0 0.0 0.0 0.0)
 t_mbb7 = (MBB 1.0 2.0 5.0 4.0)
 t_mbb8 = (MBB 4.0 0.0 6.0 3.0)
 
-t_1, t_2, t_3, t_4, t_5, t_6, t_7, t_8 :: RTree String
+t_1, t_2, t_3 :: RTree String
 t_1 = singleton t_mbb1 "a"
 t_2 = singleton t_mbb2 "b"
 t_3 = singleton t_mbb3 "c"
-t_4 = singleton t_mbb4 "d"
-t_5 = singleton t_mbb5 "e"
-t_6 = singleton t_mbb6 "f"
-t_7 = singleton t_mbb7 "g"
-t_8 = singleton t_mbb8 "h"
 
 
 u_1, u_2, u_3 :: [(MBB, String)]

--- a/test/RTreeStrict.hs
+++ b/test/RTreeStrict.hs
@@ -13,8 +13,6 @@ import            Prelude                              hiding (lookup, map, mapM
 import            Control.Applicative ((<$>))
 import            Control.DeepSeq                      (($!!))
 
-import            Data.Monoid
-
 import            Data.RTree.Strict
 import qualified  Data.RTree as L
 import            Data.RTree.MBB
@@ -165,9 +163,9 @@ instance QA.Arbitrary MBB where
         w <- QA.arbitrary `suchThat` (>=0)
         return $ MBB (cx - w) (cy - h) (cx + w) (cy + h)
 
-    shrink mbb@(MBB ulx uly brx bry)
-        | isPointMBB mbb = []
-        | otherwise      = [MBB (mid ulx brx) (mid uly bry) (mid ulx brx) (mid uly bry)]
+    shrink this_mbb@(MBB ulx uly brx bry)
+        | isPointMBB this_mbb = []
+        | otherwise           = [MBB (mid ulx brx) (mid uly bry) (mid ulx brx) (mid uly bry)]
         where
             mid x y = (y - x) / 2
 


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

There are two warnings left:

```
/r-tree/Data/RTree/Base.hs:82:1: warning: [-Wunused-imports]
    The import of ‘Data.Semigroup’ is redundant
      except perhaps to import instances from ‘Data.Semigroup’
    To import instances alone, use: import Data.Semigroup()
   |        
82 | import           Data.Semigroup
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[3 of 4] Compiling Data.RTree
[4 of 4] Compiling Data.RTree.Strict
            
/r-tree/Data/RTree/Strict.hs:67:1: warning: [-Wunused-imports]
    The import of ‘Data.Semigroup’ is redundant
      except perhaps to import instances from ‘Data.Semigroup’
    To import instances alone, use: import Data.Semigroup()
   |        
67 | import           Data.Semigroup
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

cc @newhoggy 