### PR TITLE
Making the library GHC 9.0+ compatible

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc-version: [8.4.4, 8.6.5, 8.8.2]
+        ghc-version: [8.4.4, 8.6.5, 8.8.2, 8.10.4, 9.0.1]
   
     runs-on: ubuntu-18.04
 

--- a/Data/RTree/Base.hs
+++ b/Data/RTree/Base.hs
@@ -83,11 +83,11 @@ import           Prelude         hiding (length, lookup, map, null)
 import           Data.RTree.MBB  hiding (mbb)
 
 data RTree a =
-      Node4 {getMBB :: {-# UNPACK #-} ! MBB, getC1 :: ! (RTree a), getC2 :: ! (RTree a), getC3 :: ! (RTree a), getC4 :: ! (RTree a) }
-    | Node3 {getMBB :: {-# UNPACK #-} ! MBB, getC1 :: ! (RTree a), getC2 :: ! (RTree a), getC3 :: ! (RTree a) }
-    | Node2 {getMBB :: {-# UNPACK #-} ! MBB, getC1 :: ! (RTree a), getC2 :: ! (RTree a) }
+      Node4 {getMBB :: {-# UNPACK #-} !MBB, getC1 :: !(RTree a), getC2 :: !(RTree a), getC3 :: !(RTree a), getC4 :: !(RTree a) }
+    | Node3 {getMBB :: {-# UNPACK #-} !MBB, getC1 :: !(RTree a), getC2 :: !(RTree a), getC3 :: !(RTree a) }
+    | Node2 {getMBB :: {-# UNPACK #-} !MBB, getC1 :: !(RTree a), getC2 :: !(RTree a) }
     | Node  {getMBB ::                  MBB, getChildren' :: [RTree a] }
-    | Leaf  {getMBB :: {-# UNPACK #-} ! MBB, getElem :: a}
+    | Leaf  {getMBB :: {-# UNPACK #-} !MBB, getElem :: a}
     | Empty
     deriving (Show, Eq, Typeable, Generic, Functor)
 

--- a/Data/RTree/MBB.hs
+++ b/Data/RTree/MBB.hs
@@ -34,7 +34,7 @@ import Data.Binary
 import GHC.Generics (Generic)
 
 -- | Minimal bounding box
-data MBB = MBB {getUlx :: {-# UNPACK #-} ! Double, getUly :: {-# UNPACK #-} ! Double, getBrx :: {-# UNPACK #-} ! Double, getBry :: {-# UNPACK #-} ! Double}
+data MBB = MBB {getUlx :: {-# UNPACK #-} !Double, getUly :: {-# UNPACK #-} !Double, getBrx :: {-# UNPACK #-} !Double, getBry :: {-# UNPACK #-} !Double}
     deriving (Eq, Generic, Ord)
 
 -- | created a minimal bounding box (or a rectangle)

--- a/data-r-tree.cabal
+++ b/data-r-tree.cabal
@@ -33,7 +33,7 @@ common containers                   { build-depends: containers                 
 common deepseq                      { build-depends: deepseq                        >= 1.4        && < 1.5    }
 common ghc-heap-view                { build-depends: ghc-heap-view                  >= 0.5        && < 0.7    }
 common HUnit                        { build-depends: HUnit                          >= 1.6        && < 1.7    }
-common QuickCheck                   { build-depends: QuickCheck                     >= 2.13       && < 2.14   }
+common QuickCheck                   { build-depends: QuickCheck                     >= 2.13       && < 2.15   }
 common test-framework               { build-depends: test-framework                 >= 0.8        && < 0.9    }
 common test-framework-hunit         { build-depends: test-framework-hunit           >= 0.3        && < 0.4    }
 common test-framework-quickcheck2   { build-depends: test-framework-quickcheck2     >= 0.3        && < 0.4    }


### PR DESCRIPTION
As per [9.0 migration guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#whitespace-sensitive-and-), bang patterns no longer parse correctly in presence of trailing whitespace.